### PR TITLE
Update Docker image name and registry in pipeline

### DIFF
--- a/pipelines/azure-pipelines.yaml
+++ b/pipelines/azure-pipelines.yaml
@@ -1,4 +1,3 @@
-
 name: $(date:yyyyMMdd)-$(rev:.r)
 
 parameters:
@@ -27,7 +26,7 @@ variables:
   - name: VM_IMAGE
     value: ubuntu-latest
   - name: IMAGE_NAME
-    value: "think-cube/docker-bash"
+    value: "thinkcubedev/bash"
 
 pool:
   vmImage: $(VM_IMAGE)
@@ -57,17 +56,11 @@ stages:
     steps:
     - checkout: self
     - script: echo "##vso[task.setvariable variable=IMAGE_TAG]$(date +%Y%m%d)"
-      displayName: "Set IMAGE_TAG variable"    
-    - task: Docker@2
-      inputs:
-        command: 'login'
-        containerRegistry: 'ghcr.io'
-        username: '$(USERNAME)'
-        password: '$(TOKEN-FOR-GHCR)'
+      displayName: "Set IMAGE_TAG variable"
 
     - task: Docker@2
       inputs:
-        containerRegistry: 'ghcr.io'
+        containerRegistry: 'DockerHub_thinkcubedev'
         repository: '$(IMAGE_NAME)'
         command: 'buildAndPush'
         Dockerfile: 'Dockerfile'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image publishing to target Docker Hub.
  * Renamed the published image from "think-cube/docker-bash" to "thinkcubedev/bash" for consistency.
  * Simplified the publish process by removing an unnecessary registry login step.
  * Minor ordering/formatting adjustment for image tag setting in the publish flow.

Impact: Pull the image from Docker Hub using "thinkcubedev/bash".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->